### PR TITLE
Rename virtualbox package and dependency variables for more clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ None
 #### Variables
 
 * `virtualbox_version` [default: `5.2`]: Version to install
-* `virtualbox_install`: [default: `[]`]: Additional packages to install (e.g. `dkms`)
+* `virtualbox_additional_package_list`: [default: `[]`]: Additional packages to install (e.g. `dkms`)
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 # defaults file for virtualbox
 ---
 virtualbox_version: 5.2
-virtualbox_install: []
+virtualbox_additional_package_list: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,15 +1,15 @@
 # tasks file for virtualbox
 ---
-- name: install dependencies
-  apt:
-    name: "{{ virtualbox_dependencies }}"
+- name: install virtualbox
+  package:
+    name: "{{ virtualbox_package }}"
     state: "{{ apt_install_state | default('latest') }}"
   tags:
     - virtualbox-install-dependencies
 
-- name: install
-  apt:
-    name: "{{ virtualbox_install }}"
+- name: install virtualbox additional packages
+  package:
+    name: "{{ virtualbox_additional_package_list }}"
     state: "{{ apt_install_state | default('latest') }}"
   tags:
     - virtualbox-install-additional

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,5 +10,5 @@ virtualbox_public_keys:
   - id: A2F683C52980AECF
     url: https://www.virtualbox.org/download/oracle_vbox_2016.asc
 
-virtualbox_dependencies:
+virtualbox_package:
   - "virtualbox-{{ virtualbox_version }}"


### PR DESCRIPTION
First of let me thank you for making this role public. Thanks!
Maybe this is just style but I was extremely confused that the "Install" part installs actually the additional components and the "Install dependencies" actually installs virtualbox.
Moving from "apt" to the ansible "package" module makes it generally more modular, though it is not yet ready for other OS due to the repository.yml. 
Feel free to close it if you don't like it.
